### PR TITLE
Remove WITH_DEXPREOPT flag

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -136,14 +136,5 @@ BOARD_HOSTAPD_DRIVER := NL80211
 TARGET_CUSTOM_WIFI := ../../device/huawei/msm7x27a-common/libhardware_legacy/wifi/wifi.c
 WPA_SUPPLICANT_VERSION := VER_0_8_X
 
-# Enable dex-preoptimization to speed up first boot sequence
-ifeq ($(HOST_OS),linux)
-  ifeq ($(TARGET_BUILD_VARIANT),user)
-    ifeq ($(WITH_DEXPREOPT),)
-      WITH_DEXPREOPT := true
-    endif
-  endif
-endif
-
 # Include an expanded selection of fonts
 EXTENDED_FONT_FOOTPRINT := true


### PR DESCRIPTION
As Android "wiki" say :
The goal of these compiler options is to utilize available space in the system and data partition to reduce the amount of dex2oat that must be performed by the device.

For devices with ample system and data space, enabling dex pre-optimization is all that is necessary

So remove this as our /data /system partiton are small
