### PR TITLE
msm7x27a: background apps limit to 8

### DIFF
--- a/msm7x27a.mk
+++ b/msm7x27a.mk
@@ -173,7 +173,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
     dalvik.vm.jit.codecachesize=0 \
     persist.sys.force_highendgfx=true \
     ro.config.max_starting_bg=6 \
-    ro.sys.fw.bg_apps_limit=16
+    ro.sys.fw.bg_apps_limit=8
     
 # FM Radio
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
I think on lollipop 16 it's a high value for a lowmem device..

_Also for CM13_
